### PR TITLE
Feature/loading loading画面追加、DB接続タイミングをloadingアクセス時に変更

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,5 +43,5 @@ input:-webkit-autofill:hover {
     これがないと、アニメーション終了後に最初の状態（非表示）に戻ってしまいます。
     'forwards' を指定することで、アニメーションが最後の状態（完全表示）で停止します。
   */
-  animation: reveal-from-bottom 1.3s ease-in-out forwards;
+  animation: reveal-from-bottom 1.0s ease-in-out 3 forwards;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,3 +23,25 @@ input:-webkit-autofill:hover {
   border: 1px solid #1B6AAC !important;           /* brand.blue */
   box-shadow: 0 0 0 2px #1B6AAC !important;       /* 簡易 ring 代替 */
 }
+
+/* GANTZ風の表示アニメーションを定義 */
+@keyframes reveal-from-bottom {
+  /* 開始時（0%）: 要素の上辺から100%の位置で切り抜き、ほぼ完全に非表示にする */
+  from {
+    clip-path: inset(95% 0 0 0);
+  }
+  /* 終了時（100%）: 切り抜きをなくし、完全に表示する */
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+/* 上記のアニメーションを適用するためのユーティリティクラス */
+.animate-reveal-from-bottom {
+  /*
+    animation-fill-mode: forwards; が非常に重要です。
+    これがないと、アニメーション終了後に最初の状態（非表示）に戻ってしまいます。
+    'forwards' を指定することで、アニメーションが最後の状態（完全表示）で停止します。
+  */
+  animation: reveal-from-bottom 1.3s ease-in-out forwards;
+}

--- a/src/app/loading/page.tsx
+++ b/src/app/loading/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { PostDataLoader } from "@/components/functional/PostDataLoader";
+
+// ロゴ画像のパス
+const PATHS = {
+  appLogo: "/images/app_logo.png",
+  appFontLogo: "/images/app_logo_font.png",
+};
+
+export default function Loading() {
+  const router = useRouter();
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    // スプラッシュ画面全体の表示時間を設定（ミリ秒単位でアニメーション時間より長くします）
+    const totalDisplayTime = 1500;
+
+    const timer = setTimeout(() => {
+      setIsVisible(false); // フェードアウト開始
+
+      setTimeout(() => {
+        router.push("/home"); // 遷移先
+      }, 200); // フェードアウトの時間
+    }, totalDisplayTime);
+
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <>
+      {/* ページが読み込まれた瞬間にデータ取得を開始するために設置します */}
+      {/* このコンポーネントは画面には何も表示しません */}
+      <PostDataLoader />
+      <div
+        className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-white transition-opacity duration-300 ${
+          isVisible ? "opacity-100" : "opacity-0"
+        }`}
+        aria-hidden={!isVisible}
+      >
+        <p className="text-xl font-semibold text-gray-700 animate-pulse mb-8">
+          あなたの街を作っています...
+        </p>
+        <div className="text-center">
+          {/* アニメーションを適用するラッパー */}
+          <div className="mb-8 w-64">
+            {" "}
+            {/* w-64 の部分で画像の最大幅を調整 */}
+            <Image
+              src={PATHS.appLogo}
+              alt="TOMOSU ロゴ"
+              width={144 * 2}
+              height={168 * 2}
+              priority // 最初に表示される重要な画像なのでpriorityを指定
+              className="animate-reveal-from-bottom" // Step 1 で作成したクラスを適用！
+            />
+          </div>
+
+          {/* TOMOSUロゴフォント */}
+          <div className="mb-6 flex justify-center">
+            <Image
+              src={PATHS.appFontLogo}
+              alt="TOMOSU ロゴフォント"
+              width={228 * 2}
+              height={65 * 2}
+              className="h-auto w-44 md:w-48"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/loading/page.tsx
+++ b/src/app/loading/page.tsx
@@ -17,7 +17,7 @@ export default function Loading() {
 
   useEffect(() => {
     // スプラッシュ画面全体の表示時間を設定（ミリ秒単位でアニメーション時間より長くします）
-    const totalDisplayTime = 1500;
+    const totalDisplayTime = 3500;
 
     const timer = setTimeout(() => {
       setIsVisible(false); // フェードアウト開始
@@ -32,41 +32,37 @@ export default function Loading() {
 
   return (
     <>
-      {/* ページが読み込まれた瞬間にデータ取得を開始するために設置します */}
-      {/* このコンポーネントは画面には何も表示しません */}
       <PostDataLoader />
-      <div
-        className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-white transition-opacity duration-300 ${
-          isVisible ? "opacity-100" : "opacity-0"
-        }`}
-        aria-hidden={!isVisible}
-      >
+      {/* ★★★ ここからが大きな変更点 ★★★ */}
+      {/* fixedをやめ、flexboxで中央揃えを実現する */}
+      {/* flex-1: 親要素(flex-col)の残りの空間をすべて埋める */}
+      <div className="flex flex-1 flex-col items-center justify-center">
         <p className="text-xl font-semibold text-gray-700 animate-pulse mb-8">
           あなたの街を作っています...
         </p>
         <div className="text-center">
           {/* アニメーションを適用するラッパー */}
-          <div className="mb-8 w-64">
+          <div className="mb-8 w-44">
             {" "}
             {/* w-64 の部分で画像の最大幅を調整 */}
             <Image
               src={PATHS.appLogo}
               alt="TOMOSU ロゴ"
-              width={144 * 2}
-              height={168 * 2}
+              width={144}
+              height={168}
               priority // 最初に表示される重要な画像なのでpriorityを指定
-              className="animate-reveal-from-bottom" // Step 1 で作成したクラスを適用！
+              className="animate-reveal-from-bottom w-full h-auto" // Step 1 で作成したクラスを適用！
             />
           </div>
 
           {/* TOMOSUロゴフォント */}
-          <div className="mb-6 flex justify-center">
+          <div className="mb-6 flex justify-center w-44">
             <Image
               src={PATHS.appFontLogo}
               alt="TOMOSU ロゴフォント"
-              width={228 * 2}
-              height={65 * 2}
-              className="h-auto w-44 md:w-48"
+              width={228}
+              height={65}
+              className="h-auto w-full"
             />
           </div>
         </div>

--- a/src/app/mytokyogas-login/page.tsx
+++ b/src/app/mytokyogas-login/page.tsx
@@ -16,7 +16,7 @@ export default function Login() {
   const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     // TODO: バリデーション & API 連携
-    router.push("/home");
+    router.push("/loading");
   };
 
   // 共通コンテナ（Header/Main で完全に揃える）
@@ -41,7 +41,7 @@ export default function Login() {
           >
             <Image src={ICONS.arrowLeft} alt="戻る" width={24} height={24} />
           </Link>
-          <h1 className="pt-20 pb-2 text-[24px] font-bold tracking-[-0.48px] text-text-primary">
+          <h1 className="pt-10 pb-4 text-[24px] font-bold tracking-[-0.48px] text-text-primary">
             myTOKYO GAS IDでログイン
           </h1>
         </div>
@@ -123,7 +123,7 @@ export default function Login() {
                 href="#"
                 className="inline-flex h-[61px] w-full items-center justify-center rounded-[10px] border border-brand-blue bg-white px-4 text-[19px] font-bold tracking-[-0.41px] text-brand-blue shadow-sm transition-opacity hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/50 focus-visible:ring-offset-2"
               >
-                はじめてご利用の方
+                はじめてご利用の方 (未実装)
               </Link>
 
               {/* 会員登録について（ボタン直下） */}

--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -2,12 +2,11 @@
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
-import { PostDataLoader } from "@/components/functional/PostDataLoader";
 
 const TEXT = {
   tagline: "-あなたの想いが、まちを灯す-",
   login: "myTOKYOGASでログイン",
-  guest: "未契約者の方はこちら",
+  guest: "未契約の方はこちら (未実装)",
   powered: "powered by TOKYOGAS",
   brandAlt: "TOKYO GAS ロゴ",
   appLogoAlt: "TOMOSU メインロゴ（炎アイコン）",
@@ -16,7 +15,7 @@ const TEXT = {
 
 const PATHS = {
   login: "/mytokyogas-login",
-  guest: "/guest", // TODO: 遷移先が未確定の場合は「#」等に変更
+  guest: "#", // TODO: 遷移先が未確定の場合は「#」等に変更
   appLogo: "/images/app_logo.png",
   appFontLogo: "/images/app_logo_font.png",
   brandLogo: "/icons/brand_logo.svg",
@@ -24,92 +23,86 @@ const PATHS = {
 
 export default function Home() {
   return (
-    <>
-      {/* ページが読み込まれた瞬間にデータ取得を開始するために設置します */}
-      {/* このコンポーネントは画面には何も表示しません */}
-      <PostDataLoader />
+    <div className="flex min-h-screen w-full flex-col bg-white">
+      {/* Header */}
+      <header className="pt-20" aria-label="アプリのヘッダー">
+        <h1 className="sr-only">TOMOSU</h1>
+      </header>
 
-      <div className="flex min-h-screen w-full flex-col bg-white">
-        {/* Header */}
-        <header className="pt-20" aria-label="アプリのヘッダー">
-          <h1 className="sr-only">TOMOSU</h1>
-        </header>
-
-        {/* Main */}
-        <main className="flex flex-1 flex-col items-center px-4" role="main">
-          {/* サブタイトル */}
-          <p
-            className="mt-12 mb-10 text-center text-[20px] font-bold tracking-[-0.4px] text-[#3c3c3c]"
-            aria-label="サブタイトル"
-          >
-            {TEXT.tagline}
-          </p>
-
-          {/* メインロゴ（炎アイコン） */}
-          <div className="mt-4 mb-4 flex justify-center">
-            <Image
-              src={PATHS.appLogo}
-              alt={TEXT.appLogoAlt}
-              width={144}
-              height={168}
-              priority
-              className="h-auto w-28 md:w-32"
-            />
-          </div>
-
-          {/* TOMOSUロゴフォント */}
-          <div className="mb-6 flex justify-center">
-            <Image
-              src={PATHS.appFontLogo}
-              alt={TEXT.appFontAlt}
-              width={228}
-              height={65}
-              className="h-auto w-44 md:w-48"
-            />
-          </div>
-
-          {/* powered by（サブテキスト） */}
-          <div className="mb-8 flex justify-center">
-            <span className="text-xs text-[#c4c4c4]">{TEXT.powered}</span>
-          </div>
-
-          {/* アクションボタン群 */}
-          <div className="mb-8 flex w-full max-w-[343px] flex-col items-stretch gap-4">
-            <Link
-              href={PATHS.login}
-              aria-label="myTOKYOGASでログイン"
-              className="inline-flex h-[61px] items-center justify-center rounded-[10px] bg-[#1b6aac] text-[19px] font-bold tracking-[-0.41px] text-white outline-none transition-[opacity,box-shadow] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#1b6aac]/60 hover:opacity-95 active:opacity-90"
-            >
-              {TEXT.login}
-            </Link>
-
-            <Link
-              href={PATHS.guest}
-              aria-label="未契約者の方はこちら"
-              className="inline-flex h-[61px] items-center justify-center rounded-[10px] bg-[#dedede] text-[19px] font-bold tracking-[-0.41px] text-[#5a5a5a] outline-none transition-[opacity,box-shadow] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#9e9e9e]/50 hover:opacity-95 active:opacity-90"
-            >
-              {TEXT.guest}
-            </Link>
-          </div>
-        </main>
-
-        {/* Footer */}
-        <footer
-          className="mt-auto mb-6 flex w-full items-center justify-center px-4"
-          aria-label="フッター"
+      {/* Main */}
+      <main className="flex flex-1 flex-col items-center px-4" role="main">
+        {/* サブタイトル */}
+        <p
+          className="mt-12 mb-10 text-center text-[20px] font-bold tracking-[-0.4px] text-[#3c3c3c]"
+          aria-label="サブタイトル"
         >
-          <div className="w-full max-w-[120px]">
-            <Image
-              src={PATHS.brandLogo}
-              alt={TEXT.brandAlt}
-              width={100}
-              height={32}
-              priority
-              className="h-auto w-full"
-            />
-          </div>
-        </footer>
-      </div>
-    </>
+          {TEXT.tagline}
+        </p>
+
+        {/* メインロゴ（炎アイコン） */}
+        <div className="mt-4 mb-4 flex justify-center">
+          <Image
+            src={PATHS.appLogo}
+            alt={TEXT.appLogoAlt}
+            width={144}
+            height={168}
+            priority
+            className="h-auto w-28 md:w-32"
+          />
+        </div>
+
+        {/* TOMOSUロゴフォント */}
+        <div className="mb-6 flex justify-center">
+          <Image
+            src={PATHS.appFontLogo}
+            alt={TEXT.appFontAlt}
+            width={228}
+            height={65}
+            className="h-auto w-44 md:w-48"
+          />
+        </div>
+
+        {/* powered by（サブテキスト） */}
+        <div className="mb-8 flex justify-center">
+          <span className="text-xs text-[#c4c4c4]">{TEXT.powered}</span>
+        </div>
+
+        {/* アクションボタン群 */}
+        <div className="mb-8 flex w-full max-w-[343px] flex-col items-stretch gap-4">
+          <Link
+            href={PATHS.login}
+            aria-label="myTOKYOGASでログイン"
+            className="inline-flex h-[61px] items-center justify-center rounded-[10px] bg-[#1b6aac] text-[19px] font-bold tracking-[-0.41px] text-white outline-none transition-[opacity,box-shadow] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#1b6aac]/60 hover:opacity-95 active:opacity-90"
+          >
+            {TEXT.login}
+          </Link>
+
+          <Link
+            href={PATHS.guest}
+            aria-label="未契約者の方はこちら"
+            className="inline-flex h-[61px] items-center justify-center rounded-[10px] bg-[#dedede] text-[19px] font-bold tracking-[-0.41px] text-[#5a5a5a] outline-none transition-[opacity,box-shadow] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#9e9e9e]/50 hover:opacity-95 active:opacity-90"
+          >
+            {TEXT.guest}
+          </Link>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer
+        className="mt-auto mb-6 flex w-full items-center justify-center px-4"
+        aria-label="フッター"
+      >
+        <div className="w-full max-w-[120px]">
+          <Image
+            src={PATHS.brandLogo}
+            alt={TEXT.brandAlt}
+            width={100}
+            height={32}
+            priority
+            className="h-auto w-full"
+          />
+        </div>
+      </footer>
+    </div>
   );
 }


### PR DESCRIPTION
下記の処理を実装しています。

- mytokyogas-login画面でログインボタンを押す
- loading画面に遷移する
  - ページ全体の表示時間: 3500 ms
  - アニメーションの幅: 下5%は常時表示、残り95%を 1000 msかけて表示×3回
  - 画像サイズ: w-44 （横幅176px）で設定（元サイズは幅144px）
  - ロゴテキストサイズ: w-44 （横幅176px）で設定（元サイズは幅228px）
  - 「あなたの街を作っています...」テキスト: animation-pulseで色をちらちら変更
- 裏ではDBに接続してタイムラインのデータを読み込む
- アニメーションが終わったら画面全体をフェードアウトしつつhomeに自動遷移する
  - フェードアウトの時間: 200 ms

run build確認済み